### PR TITLE
Adds RBAC template

### DIFF
--- a/technical-on-boarding/templates/rbac.yaml
+++ b/technical-on-boarding/templates/rbac.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-nginx-ingress-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+      - configmaps
+    verbs:
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-nginx-ingress-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-nginx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Adds rbac configuration for purposes of using in combination with community nginx ingress controller

The community helm chart for nginx ingress is not configured with the correct RBAC permissions to be used in a cluster using RBAC. It is preferable to use the community chart, as app registry is being deprecated. While waiting to submit and navigate an upsteam pull request to the community chart, we are packaging the RBAC permissions with this app so that it can be operated and run in any cluster from anywhere, in combination with the nginx ingress controller stable/nginx-ingress. If and when the community chart supports RBAC permissions, this template will be removed.